### PR TITLE
time slot refactor and styling

### DIFF
--- a/src/components/dashboards/Admin-dashboard.tsx
+++ b/src/components/dashboards/Admin-dashboard.tsx
@@ -252,7 +252,7 @@ export default function AdminDashboard() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-100 py-10 px-4">
+    <div className="min-h-screen bg-gray-100 py-10">
       <ToastContainer position="top-right" autoClose={3000} hideProgressBar />
       <h2 className="py-4 text-2xl font-bold">
         Welcome, {session.user.name} (Admin)
@@ -478,8 +478,8 @@ const RouteOptimizerModal = ({
   dateValue: string;
 }) => {
   return (
-    <div className="absolute w-full top-[0] h-full bg-simmpy-gray-900/60">
-      <div className="modal-box w-full max-w-[800px] lg:ml-[30%] p-4 rounded-md mt-[20vh] bg-simmpy-gray-100">
+    <div className="absolute w-full top-[0] h-[100vh] bg-simmpy-gray-900/60">
+      <div className="modal-box w-full max-w-[800px] h-[100vh] p-4 rounded-md mt-[6vh] bg-simmpy-gray-100">
         <div className="flex justify-end">
           <button onClick={onClose}>X</button>
         </div>

--- a/src/components/submission-form/Time-slot-picker.tsx
+++ b/src/components/submission-form/Time-slot-picker.tsx
@@ -2,7 +2,7 @@ import { getTimeSlotHoursClock } from "@/lib/utils/time-slot/time-slot";
 import { RequestedAvailabilityApiResponse } from "@/types/api-responses/requested-timeslot-availability-api-response.ts/requested-availability-api-response";
 import { TimeSlot } from "@/types/time-slot";
 import { Radio, RadioGroup, RadioProps, cn } from "@nextui-org/react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 interface TimeSlotPickerProps {
   value?: TimeSlot | string;
@@ -26,6 +26,16 @@ export const TimeSlotPicker = ({
     setSelected(value);
     onChange?.(value as TimeSlot);
   };
+
+  useEffect(() => {
+    const updatedValue = getAvailableTimeslot(
+      availabilities.availabilities!,
+      value || TimeSlot.Morning
+    );
+    setSelected(updatedValue);
+
+    onChange?.(updatedValue as TimeSlot);
+  }, [availabilities]);
 
   return (
     <RadioGroup

--- a/src/components/submission-form/steps/FormStepThree.tsx
+++ b/src/components/submission-form/steps/FormStepThree.tsx
@@ -23,6 +23,7 @@ interface FormStepThreeProps {
 export const FormStepThree = ({
   formData,
   setFormData,
+  errors,
 }: FormStepThreeProps) => {
   const [appointmentDate, setAppointmentDate] = useState(
     toCalendarDateFromJSDate(formData.appointmentDate!)
@@ -103,6 +104,14 @@ export const FormStepThree = ({
               availabilities={slotAvailabilities}
             />
           </div>
+        )}
+      </div>
+      <div>
+        {errors.appointmentDate && (
+          <p className="text-red-500">Select an available appointment date.</p>
+        )}
+        {errors.timeSlot && (
+          <p className="text-red-500">Select an available time slot</p>
         )}
       </div>
       <div className="flex">


### PR DESCRIPTION
Fix bug for timeslot picking in the submission form:
- when user selects a calendar date, it checks for available slots for that date and greys-out unavailable dates properly
- if user tries to progress in the submission form without picking a valid date and timeslot, it will show an error